### PR TITLE
Added clarification message that teams need to recreate their team on the HSS

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -139,6 +139,9 @@
             {% if using_teams and (is_registration_open() or application is not none) %}
             <div class="borderTopDiv z-depth-3">
                 <h2 class="formH2">Apply as a team</h2>
+                <div style="background-color: #ffffcc; border-left: 6px solid #ffeb3b; margin-bottom: 15px; padding: 4px 12px">
+                    <p>Note: when accessing our <a href="https://hardware.makeuoft.ca" target="_blank">Hardware Sign out Site</a> to borrow items from our inventory, you'll have to re-create your team on that portal.</p>
+                </div>
                 <p>Have friends you want to work with? Create a team with up to 4 people and we’ll review your applications together.</p>
                 <br />
                 {% if application is none %}


### PR DESCRIPTION

## Overview

- Refer to text on the dashboard page under 'Apply as a team' section


## Unit Tests Created

- n/a


## Steps to QA

- n/a

